### PR TITLE
Template checkpoints

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 class GreatExpectationsOperator(BaseOperator):
     ui_color = '#AFEEEE'
     ui_fgcolor = '#000000'
-    template_fields = ['checkpoint_name']
+    template_fields = ['checkpoint_name', 'batch_kwargs', 'assets_to_validate']
 
     @apply_defaults
     def __init__(self,

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -30,6 +30,7 @@ log = logging.getLogger(__name__)
 class GreatExpectationsOperator(BaseOperator):
     ui_color = '#AFEEEE'
     ui_fgcolor = '#000000'
+    template_fields = ['checkpoint_name']
 
     @apply_defaults
     def __init__(self,


### PR DESCRIPTION
Makes checkpoint name templateable. This makes it a lot easier to e.g. validate against staging table using airflow macros.
E.g when you have a daily generated staging table test_staging_tbl_201123 that you want to validate that against you can just specify the query in you checkpoint to use test_staging_tb_{{ ds_nodash }}