### PR TITLE
[BUGFIX] jinja template fields not rendering

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 class GreatExpectationsOperator(BaseOperator):
     ui_color = '#AFEEEE'
     ui_fgcolor = '#000000'
-    template_fields = ['checkpoint_name', 'batch_kwargs', 'assets_to_validate']
+    template_fields = ('checkpoint_name', 'batch_kwargs', 'assets_to_validate')
 
     @apply_defaults
     def __init__(self,


### PR DESCRIPTION
The bug is that jinja template fields like `batch_kwargs` don't render. The fix is to make `template_fields` on line 33  a tuple instead of a list.

I'm not sure why though. The airflow [docs ](https://airflow.apache.org/docs/apache-airflow/2.0.0/howto/custom-operator.html#templating) clearly use a list.

However a tuple makes everything work great on my 2.0.0-2 airflow version. Also, other [provider packages](https://github.com/apache/airflow/blob/master/airflow/providers/amazon/aws/operators/athena.py) I've tested successfully use tuples for the `template_fields` as well.

