### PR TITLE
Add option to automatically generate data docs

### DIFF
--- a/great_expectations_provider/examples/example_great_expectations_dag.py
+++ b/great_expectations_provider/examples/example_great_expectations_dag.py
@@ -114,4 +114,19 @@ bq_task = GreatExpectationsBigQueryOperator(
     dag=dag
 )
 
+# This runs an expectation suite against a data asset that passes the tests
+# and automatically generates the Great Expectations data docs at your local path
+# under great_expectations/data_docs
+data_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/yellow_tripdata_sample_2019-01.csv')
+ge_batch_kwargs_pass = GreatExpectationsOperator(
+    task_id='ge_batch_kwargs_pass',
+    expectation_suite_name='taxi.demo',
+    generate_local_datadocs=True,
+    batch_kwargs={
+        'path': data_file,
+        'datasource': 'data__dir'
+    },
+    dag=dag
+)
+
 # TODO: Add an example for creating an in-memory data context using a dictionary config

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -45,6 +45,7 @@ class GreatExpectationsOperator(BaseOperator):
                  fail_task_on_validation_failure=True,
                  on_failure_callback=None,
                  validation_operator_name="action_list_operator",
+                 generate_local_datadocs=False,
                  **kwargs
                  ):
         """
@@ -92,6 +93,7 @@ class GreatExpectationsOperator(BaseOperator):
         self.fail_task_on_validation_failure = fail_task_on_validation_failure
         self.on_failure_callback = on_failure_callback
         self.validation_operator_name = validation_operator_name
+        self.generate_local_datadocs = generate_local_datadocs
 
     def execute(self, context):
         log.info("Running validation with Great Expectations...")
@@ -127,6 +129,9 @@ class GreatExpectationsOperator(BaseOperator):
             assets_to_validate=batches_to_validate,
             run_name=self.run_name
         )
+
+        if self.generate_local_datadocs:
+            self.data_context.build_data_docs()
 
         if not results["success"]:
             if self.fail_task_on_validation_failure:


### PR DESCRIPTION
We're using the GE Airflow operator for triggering automated data validations. We wanted to go one step further and automatically generate and publish the corresponding data docs. 

So I added this option. It will generate the data docs HTML structure at the local path on the Airflow instance (great_expectations/data_docs). This data docs can then be published for example by [pushing them to S3](https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_docs/how_to_host_and_share_data_docs_on_s3.html).

Please note: I opened a PR first with a wrong email adress, so I closed it and re-opened it here.