### PR TITLE
[BUGFIX] Update operator to work with Checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Apache Airflow Provider for Great Expectations
 
+## 0.0.5
+* [BREAKING] Updated GreatExpectations operator to work with class-based Checkpoints (Great Expectations >= 0.13.8)  
+
 ## 0.0.4
 * [ENHANCEMENT] Adding BigQuery operator for easier use with BigQuery and Google Cloud Storage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Apache Airflow Provider for Great Expectations
 
 ## 0.0.5
-* [BREAKING] Updated GreatExpectations operator to work with class-based Checkpoints (Great Expectations >= 0.13.8)  
+* [BREAKING] Updated GreatExpectations operator to work with class-based Checkpoints (Great Expectations >= 0.13.9)  
 
 ## 0.0.4
 * [ENHANCEMENT] Adding BigQuery operator for easier use with BigQuery and Google Cloud Storage

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 An Airflow operator for [Great Expectations](greatexpectations.io), a Python library for testing and validating data.
 
+**Note**: This operator has been updated to Great Expectations Checkpoints instead of the former ValidationOperators. Therefore, it requires Great Expectations >=v0.13.9.
 ## Installation
 
 Pre-requisites: An environment running `great_expectations` and `apache-airflow`, of course.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 An Airflow operator for [Great Expectations](greatexpectations.io), a Python library for testing and validating data.
 
-**Note**: This operator has been updated to Great Expectations Checkpoints instead of the former ValidationOperators. Therefore, it requires Great Expectations >=v0.13.9.
+
+###Notes on compatibility 
+
+* This operator has been updated to use Great Expectations Checkpoints instead of the former ValidationOperators. Therefore, it requires Great Expectations >=v0.13.9, which is pinned in the requirements.txt starting with release 0.0.5.
+* Great Expectations version 0.13.8 unfortunately contained a bug that would make this operator not work.
+* Great Expectations version 0.13.7 and below will work with version 0.0.4 of this operator and below.
+
 ## Installation
 
 Pre-requisites: An environment running `great_expectations` and `apache-airflow`, of course.

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -121,35 +121,12 @@ class GreatExpectationsOperator(BaseOperator):
                     "expectation_suite_names": [asset["expectation_suite_name"]]
                 }
                 batches_to_validate.append(batch)
-
-        context_config_version = self.data_context.get_ge_config_version()
-
-        if context_config_version == 2.0:
-            instantiated_batches_to_validate = []
-            for batch in batches_to_validate:
-                for suite_name in batch["expectation_suite_names"]:
-                    instantiated_batch = self.data_context.get_batch(
-                        batch["batch_kwargs"],
-                        suite_name
-                    )
-                    instantiated_batches_to_validate.append(instantiated_batch)
-
-            results = self.data_context.run_validation_operator(
-                validation_operator_name,
-                assets_to_validate=instantiated_batches_to_validate,
-                run_name=self.run_name
-            )
-
-        elif context_config_version == 3.0:
-            results = LegacyCheckpoint(
-                name="_temp_checkpoint",
-                data_context=self.data_context,
-                batches=batches_to_validate,
-            ).run()
-
-        else:
-            raise ValueError("Great Expectations configuration version not recognized. "
-                             "Config version must be 2.0 or 3.0")
+  
+        results = LegacyCheckpoint(
+            name="_temp_checkpoint",
+            data_context=self.data_context,
+            batches=batches_to_validate,
+        ).run()
 
         if not results["success"]:
             if self.fail_task_on_validation_failure:

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -100,7 +100,6 @@ class GreatExpectationsOperator(BaseOperator):
         validation_operator_name = self.validation_operator_name
 
         if self.batch_kwargs and self.expectation_suite_name:
-            # batch = self.data_context.get_batch(self.batch_kwargs, self.expectation_suite_name)
             batch = {"batch_kwargs": self.batch_kwargs, "expectation_suite_names": [self.expectation_suite_name]}
             batches_to_validate.append(batch)
 
@@ -121,7 +120,7 @@ class GreatExpectationsOperator(BaseOperator):
                     "expectation_suite_names": [asset["expectation_suite_name"]]
                 }
                 batches_to_validate.append(batch)
-  
+
         results = LegacyCheckpoint(
             name="_temp_checkpoint",
             data_context=self.data_context,

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -125,7 +125,6 @@ class GreatExpectationsOperator(BaseOperator):
         context_config_version = self.data_context.get_ge_config_version()
 
         if context_config_version == 2.0:
-            print(f"Context config version is {context_config_version}")
             instantiated_batches_to_validate = []
             for batch in batches_to_validate:
                 for suite_name in batch["expectation_suite_names"]:
@@ -142,7 +141,6 @@ class GreatExpectationsOperator(BaseOperator):
             )
 
         elif context_config_version == 3.0:
-            print(f"Context config version is {context_config_version}")
             results = LegacyCheckpoint(
                 name="_temp_checkpoint",
                 data_context=self.data_context,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+great-expectations>=0.13.9   # package


### PR DESCRIPTION
As of Great Expectations v0.13.8, we use SimpleCheckpoints instead of the former ValidationOperators. This PR updates the airflow-provider-great-expectations to reflect this change.