### PR TITLE
Add checkpoint support for `GreatExpectationsBigQueryOperator`

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -86,10 +86,18 @@ class GreatExpectationsOperator(BaseOperator):
         else:
             self.data_context = ge.data_context.DataContext()
 
-        # Check that only the correct args to validate are passed
-        # this doesn't cover the case where only one of expectation_suite_name or batch_kwargs is specified
-        # along with one of the others, but I'm ok with just giving precedence to the correct one
-        if sum(bool(x) for x in [(expectation_suite_name and batch_kwargs), assets_to_validate, checkpoint_name]) != 1:
+        if (
+            sum(
+                bool(x)
+                for x in [
+                    (expectation_suite_name and batch_kwargs),
+                    assets_to_validate,
+                    checkpoint_name,
+                    (bool(expectation_suite_name) != bool(batch_kwargs)) * 2,
+                ]
+            )
+            != 1
+        ):
             raise ValueError("Exactly one of expectation_suite_name + batch_kwargs, assets_to_validate, \
              or checkpoint_name is required to run validation.")
 

--- a/great_expectations_provider/operators/great_expectations_bigquery.py
+++ b/great_expectations_provider/operators/great_expectations_bigquery.py
@@ -51,10 +51,6 @@ class GreatExpectationsBigQueryOperator(GreatExpectationsOperator):
             and where the validation files & data docs will be output (e.g. HTML docs showing if the data matches
             Expectations).
         :type gcp_project: str
-        :param expectations_suite_name: The name of the Expectation Suite containing the Expectations for the data.
-            The suite should be in a JSON file with the same name as the suite (e.g. if the Expectations Suite named
-            in the Expectation file is 'my_suite' then the Expectations file should be called my_suite.json)
-        :type expectations_suite_name: str
         :param gcs_bucket:  Google Cloud Storage bucket where expectation files are stored and where validation outputs
             and data docs will be saved.
             (e.g. gs://<gcs_bucket>/<gcs_expectations_prefix>/<expectations_file_name>
@@ -118,7 +114,7 @@ class GreatExpectationsBigQueryOperator(GreatExpectationsOperator):
             '''
 
     @apply_defaults
-    def __init__(self, *, gcp_project, expectation_suite_name, gcs_bucket, gcs_expectations_prefix,
+    def __init__(self, *, gcp_project, gcs_bucket, gcs_expectations_prefix,
                  gcs_validations_prefix, gcs_datadocs_prefix, query=None, table=None,
                  bq_dataset_name, email_to, datadocs_domain='none', send_alert_email=True,
                  datadocs_link_in_email=False,
@@ -149,7 +145,7 @@ class GreatExpectationsBigQueryOperator(GreatExpectationsOperator):
         # than the parent class by sending an email to the user and then throwing an Airflow exception whenever
         # data doesn't match Expectations.
         super().__init__(data_context=data_context, batch_kwargs=batch_kwargs,
-                         expectation_suite_name=expectation_suite_name, fail_task_on_validation_failure=False,
+                         fail_task_on_validation_failure=False,
                          **kwargs)
 
     def create_data_context_config(self):


### PR DESCRIPTION
Fixes [!25](https://github.com/great-expectations/airflow-provider-great-expectations/issues/25)

This commit adds the checkpoint support for `GreatExpectationsBigQueryOperator`.
Currently this has not been working since `expectation_suite_name` was listed
as a pos_arg (instead of a var_pos_arg), which made it mandatory, because the
operators use the `@apply_defaults` decorator.

I removed the pos_arg entirely, since the `self.expectation_suite_name` member
is set by the `super()` call. Another alternative would be to make it a kwarg.
In general, all airflow operators should prefer kwargs over pos_arg.

Additionally, I changed the check for mandatory kwargs in
`GreatExpectationsOperator` to the intended behaviour:

- `expectation_suite_name` and `batch_kwargs`, or
- `assets_to_validate`, or
- `checkpoint_name`

To achieve this, I added a "logical XOR" to the check -
`(bool(expectation_suite_name) != bool(batch_kwargs)) * 2` - which is only True
when only one of them is set. By multiplying it with 2 we exclude the chance of
**only** setting one of them and no other mandatory kwargs. Basically, if only
one of these two are set, it will fail (because the `sum()`) will be `!= 1`.