### PR TITLE
Update Operator on_failure_callback to match baseOperator

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -140,7 +140,8 @@ class GreatExpectationsOperator(BaseOperator):
                 if self.on_failure_callback is None:
                     raise AirflowException("Validation with Great Expectations failed.")
                 else:
-                    self.on_failure_callback(results)
+                    context["great_expectation_results"] = results
+                    self.on_failure_callback(context)
             else:
                 log.warning("Validation with Great Expectations failed. Continuing DAG execution because "
                             "fail_task_on_validation_failure is set to False.")


### PR DESCRIPTION
from airflow's [baseOperator documentation](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/baseoperator/index.html): 
```
on_failure_callback (TaskStateChangeCallback) -- a function to be called when a task instance of this task fails. a context dictionary is passed as a single parameter to this function. Context contains references to related objects to the task instance and is documented under the macros section of the API.
```

This PR proposes to change the GreatExpectationsOperator to return the context dictionary with the results object inside 