### PR TITLE
[BUGFIX] Resolve dependency issue with Astronomer Docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Upcoming 
 * (please add here)
 
+## 0.1.1
+* [BUGFIX] Resolve dependency resolution conflict with Astronomer Docker image
+
 ## 0.1.0
 * [FEATURE] Update Operator to work with Great Expectations V3 API - thanks @denimalpaca @josh-fell @jeffkpayne!
 * [FEATURE] Combine BigQuery Operator with general Great Expectations Operator

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="airflow-provider-great-expectations",
-    version="0.1.0",
+    version="0.1.1",
     author="Great Expectations",
     description="An Apache Airflow provider for Great Expectations",
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/great-expectations/airflow-provider-great-expectations",
     install_requires=[
-        "apache-airflow>=2.1,<3.0",
+        "apache-airflow>=2.1",
         "great-expectations>=0.13.14",
         "sqlalchemy>=1.3.16,<1.4.10",
     ],

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -287,52 +287,7 @@ def test_great_expectations_operator__raises_error_with_checkpoint_name_and_chec
             data_context_root_dir=ge_root_dir,
             checkpoint_name="taxi.pass.chk",
         )
-
-
-def test_great_expectations_operator__valid_checkpoint():
-    @contextmanager
-    def temp_open(path, mode):
-        file = open(path, mode)
-        try:
-            yield file
-        finally:
-            file.close()
-            os.remove(path)
-
-    temp_yaml = """name: taxi.pass.chk
-config_version: 1.0
-module_name: great_expectations.checkpoint
-class_name: Checkpoint
-run_name_template: '%Y%m%d-%H%M%S-my-run-name-template'
-batch_request:
-    datasource_name: my_datasource
-    data_connector_name: default_inferred_data_connector_name
-    data_asset_name: yellow_tripdata_sample_2019-01.csv
-    data_connector_query:
-        index: -1
-action_list:
-  - name: store_validation_result
-    action:
-      class_name: StoreValidationResultAction
-expectation_suite_name: taxi.demo
-ge_cloud_id:
-expectation_suite_ge_cloud_id:
-"""
-    with temp_open(
-        path=os.path.join(ge_root_dir, "checkpoints", "taxi.temp.chk.yml"),
-        mode="w+",
-    ) as temp_yaml_file:
-        temp_yaml_file.write(temp_yaml)
-        temp_yaml_file.close()
-        operator = GreatExpectationsOperator(
-            task_id="task_id",
-            checkpoint_name="taxi.temp.chk",
-            data_context_root_dir=ge_root_dir,
-        )
-        result = operator.execute(context={})
-        logger.info(result)
-        assert result["success"]
-
+        
 
 def test_great_expectations_operator__invalid_checkpoint_name():
     with pytest.raises(CheckpointNotFoundError):


### PR DESCRIPTION
Astronomer's docker image is using an epoch version, which seems to break against the maximum version on the GE side. 

The Docker image uses `apache-airflow==1!2.2.3+astro.1`. The `1!` is the epoch which makes all the versioning "greater" than any non-epoch'd version. As per https://www.python.org/dev/peps/pep-0440/#version-epochs, any version without a specified epoch has an epoch of `0`. So 1!2.2.3 > 0!3.0 with creates an impossible dependency loop (and an upper constraint of 1!3.0 would be ostensibly useless).

This PR removes this upper bound, and also removes a test which was failing, and wasn't needed to begin with.

