### PR TITLE
[BUGFIX] Fix error with the instantiation of a Checkpoint from a CheckpointConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Upcoming 
 * (please add here)
 
+## 0.1.2 
+* [BUGFIX] Fix error with the instantiation of a Checkpoint from a CheckpointConfig
+
 ## 0.1.1
 * [BUGFIX] Resolve dependency resolution conflict with Astronomer Docker image
 

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -29,6 +29,7 @@ from great_expectations.checkpoint.types.checkpoint_result import \
 from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (CheckpointConfig,
                                                         DataContextConfig)
+from great_expectations.data_context.util import instantiate_class_from_config
 
 
 class GreatExpectationsOperator(BaseOperator):
@@ -135,9 +136,14 @@ class GreatExpectationsOperator(BaseOperator):
                 name=self.checkpoint_name
             )
         else:
-            self.checkpoint = Checkpoint(
-                data_context=self.data_context, **self.checkpoint_config.to_json_dict()
+            self.checkpoint = instantiate_class_from_config(
+                config=self.checkpoint_config.to_json_dict(),
+                runtime_environment={"data_context": self.data_context},
+                config_defaults={"module_name": "great_expectations.checkpoint"},
             )
+            # self.checkpoint = Checkpoint(
+            #     data_context=self.data_context, **self.checkpoint_config.to_json_dict()
+            # )
 
     def execute(self, context: Any) -> [CheckpointResult, dict]:
         self.log.info("Running validation with Great Expectations...")

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -141,9 +141,6 @@ class GreatExpectationsOperator(BaseOperator):
                 runtime_environment={"data_context": self.data_context},
                 config_defaults={"module_name": "great_expectations.checkpoint"},
             )
-            # self.checkpoint = Checkpoint(
-            #     data_context=self.data_context, **self.checkpoint_config.to_json_dict()
-            # )
 
     def execute(self, context: Any) -> [CheckpointResult, dict]:
         self.log.info("Running validation with Great Expectations...")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="airflow-provider-great-expectations",
-    version="0.1.1",
+    version="0.1.2",
     author="Great Expectations",
     description="An Apache Airflow provider for Great Expectations",
     entry_points="""

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -350,4 +350,3 @@ def test_great_expectations_operator__return_json_dict():
     logger.info(result)
     assert isinstance(result, dict)
     assert result["_success"] # TODO: Update to "success" upon changes to `to_json_dict` in core GE
-    

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -349,4 +349,4 @@ def test_great_expectations_operator__return_json_dict():
     result = operator.execute(context={})
     logger.info(result)
     assert isinstance(result, dict)
-    assert result["success"]
+    assert result["_success"] # TODO: Update to "success"

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -349,4 +349,5 @@ def test_great_expectations_operator__return_json_dict():
     result = operator.execute(context={})
     logger.info(result)
     assert isinstance(result, dict)
-    assert result["_success"] # TODO: Update to "success"
+    assert result["_success"] # TODO: Update to "success" upon changes to `to_json_dict` in core GE
+    


### PR DESCRIPTION
Due to changes to the signature of the Checkpoint class, an error was being thrown when instantiating a Checkpoint from a Checkpoint Config. This PR updates the method of instantiation to use `instantiate_class_from_config` which is a more appropriate means of doing this.

It also contains changes necessary for the release of a new version.