### PR TITLE
[MAINTENANCE] Fix tests and prep release for 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Upcoming 
 * (please add here)
 
+## 0.1.3
+* [FEATURE] Improve performance by moving DataContext and Checkpoint initialization to Operator.execute() - thanks @denimalpaca
+
 ## 0.1.2 
 * [BUGFIX] Fix error with the instantiation of a Checkpoint from a CheckpointConfig
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="airflow-provider-great-expectations",
-    version="0.1.2",
+    version="0.1.3",
     author="Great Expectations",
     description="An Apache Airflow provider for Great Expectations",
     entry_points="""

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -290,12 +290,13 @@ def test_great_expectations_operator__raises_error_with_checkpoint_name_and_chec
         
 
 def test_great_expectations_operator__invalid_checkpoint_name():
+    operator = GreatExpectationsOperator(
+        task_id="task_id",
+        checkpoint_name="invalid-checkpoint.name",
+        data_context_root_dir=ge_root_dir,
+    )
     with pytest.raises(CheckpointNotFoundError):
-        operator = GreatExpectationsOperator(
-            task_id="task_id",
-            checkpoint_name="invalid-checkpoint.name",
-            data_context_root_dir=ge_root_dir,
-        )
+        operator.execute(context={})
 
 
 def test_great_expectations_operator__validation_failure_raises_exc():
@@ -349,4 +350,4 @@ def test_great_expectations_operator__return_json_dict():
     result = operator.execute(context={})
     logger.info(result)
     assert isinstance(result, dict)
-    assert result["_success"] # TODO: Update to "success" upon changes to `to_json_dict` in core GE
+    assert result["success"]


### PR DESCRIPTION
This fixes a couple of tests that were broken as a result of changes to the core library and to the operator, and also prepares for the coming release.