### PR TITLE
[MAINTENANCE] Remove upper pin of sqlalchemy and prep for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Upcoming 
 * (please add here)
 
+## 0.1.5
+* [MAINTENANCE] Remove upper pin for SqlAlchemy to enable use with later versions of apache-airflow
+
 ## 0.1.4
 * [BUGFIX] Fix bug around the instantiation of Checkpoints from CheckpointConfig
 * [DOCS] Add test and example demonstrating the use of custom expectations in an Airflow pipeline

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     install_requires=[
         "apache-airflow>=2.1",
         "great-expectations>=0.13.14",
-        "sqlalchemy>=1.3.16,<1.4.10",
+        "sqlalchemy>=1.3.16",
     ],
     packages=[
         "great_expectations_provider",

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="airflow-provider-great-expectations",
-    version="0.1.4",
+    version="0.1.5",
     author="Great Expectations",
-    description="An Apache Airflow provider for Great Expectations",
+    description="An Apache Airflow provi-der for Great Expectations",
     entry_points="""
         [apache_airflow_provider]
         provider_info=great_expectations_provider.__init__:get_provider_info

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setuptools.setup(
     name="airflow-provider-great-expectations",
     version="0.1.5",
     author="Great Expectations",
-    description="An Apache Airflow provi-der for Great Expectations",
+    description="An Apache Airflow provider for Great Expectations",
     entry_points="""
         [apache_airflow_provider]
         provider_info=great_expectations_provider.__init__:get_provider_info


### PR DESCRIPTION
This removes the pin for sqlalchemy to support later versions of apache-airflow. It also preps for a new release.