### PR TITLE
Verify CI for Airflow 3

### DIFF
--- a/great_expectations_provider/example_dags/example_great_expectations_dag.py
+++ b/great_expectations_provider/example_dags/example_great_expectations_dag.py
@@ -117,7 +117,6 @@ expectation_suite = ExpectationSuite(
 with DAG(
     dag_id="gx_provider_example_dag",
 ) as dag:
-
     validate_extract = GXValidateBatchOperator(
         task_id="validate_extract",
         configure_batch_definition=configure_pandas_batch_definition,


### PR DESCRIPTION
The release of recent (post March 2025) versions of Airflow has broken CI due to breaking changes within Airflow.